### PR TITLE
Upgrade pyfiglet to version 1.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appscript==1.2.2; sys_platform == 'darwin' # for setting the wallpaper on macOS;
 pyobjc-framework-Quartz==9.2; sys_platform == 'darwin' # for getting the screen resolution on macOS; optional, falls back to 1920x1080
 Pillow==9.5.0
 # psutil==5.9.0 # for cleaning up open files when auto-restarting on changes in development; optional
-pyfiglet==0.8.post1
+pyfiglet==1.0.2
 # PyGObject==3.42.1 # gi.repository module, used for setting the wallpaper on gnome, unity, and cinnamon; optional, falls back to gsettings CLI
 pyperclip==1.8.2
 pyxdg==0.28 # xdg module, used for wallpaper setting; optional, falls back to ~/.config


### PR DESCRIPTION
I have problems when trying to use `textual-paint` with [`uvx`](https://docs.astral.sh/uv/guides/tools/), see https://github.com/astral-sh/uv/issues/9851 for full details. 

```
$ uvx --python 3.11 textual-paint
Installed 19 packages in 16ms
Traceback (most recent call last):
  File "/home/j-vangoey/.cache/uv/archive-v0/7odsptFFgOts7-Yke6ZXO/bin/textual-paint", line 7, in <module>
    from textual_paint.paint import main
  File "/home/j-vangoey/.cache/uv/archive-v0/7odsptFFgOts7-Yke6ZXO/lib/python3.11/site-packages/textual_paint/paint.py", line 44, in <module>
    from textual_paint.canvas import Canvas
  File "/home/j-vangoey/.cache/uv/archive-v0/7odsptFFgOts7-Yke6ZXO/lib/python3.11/site-packages/textual_paint/canvas.py", line 17, in <module>
    from textual_paint.meta_glyph_font import largest_font_that_fits
  File "/home/j-vangoey/.cache/uv/archive-v0/7odsptFFgOts7-Yke6ZXO/lib/python3.11/site-packages/textual_paint/meta_glyph_font.py", line 5, in <module>
    from pyfiglet import Figlet, FigletFont  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/j-vangoey/.cache/uv/archive-v0/7odsptFFgOts7-Yke6ZXO/lib/python3.11/site-packages/pyfiglet/__init__.py", line 11, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

This is caused by `pyfiglet`, but seem to be [resolved in version v1.0.0 ](https://github.com/pwaller/pyfiglet/issues/124#issuecomment-1712744359) of that package. So this PR bumps the version of `pyfiglet`. 